### PR TITLE
Merging collectd config differences from Grafana dashboard example

### DIFF
--- a/collectd.conf.tpl
+++ b/collectd.conf.tpl
@@ -14,6 +14,9 @@ LoadPlugin interface
 LoadPlugin uptime
 LoadPlugin swap
 LoadPlugin write_graphite
+LoadPlugin processes
+LoadPlugin aggregation
+LoadPlugin match_regex
 
 <Plugin cpu>
   ReportByCpu {{ REPORT_BY_CPU | default("false") }}
@@ -46,6 +49,9 @@ LoadPlugin write_graphite
   ReportByDevice false
   ReportReserved true
   ReportInodes true
+  ValuesAbsolute true
+  ValuesPercentage true
+  ReportInodes true
 </Plugin>
 
 <Plugin "disk">
@@ -53,6 +59,15 @@ LoadPlugin write_graphite
   IgnoreSelected false
 </Plugin>
 
+<Plugin "aggregation">
+  <Aggregation>
+    Plugin "cpu"
+    Type "cpu"
+    GroupBy "Host"
+    GroupBy "TypeInstance"
+    CalculateAverage true
+  </Aggregation>
+</Plugin>
 
 <Plugin interface>
   Interface "lo"
@@ -61,6 +76,19 @@ LoadPlugin write_graphite
   IgnoreSelected true
 </Plugin>
 
+<Chain "PostCache">
+  <Rule>
+    <Match regex>
+      Plugin "^cpu$"
+      PluginInstance "^[0-9]+$"
+    </Match>
+    <Target write>
+      Plugin "aggregation"
+    </Target>
+    Target stop
+  </Rule>
+  Target "write"
+</Chain>
 
 <Plugin "write_graphite">
  <Carbon>


### PR DESCRIPTION
This should help us easily monitor one-off docker hosts with `collectd`.

The [example Grafana dashboard config][1] has some minor config differences from the upstream collectd image this repo is forked from.

[1]: https://github.com/torkelo/dashboards/blob/master/collectd-graphite-single-server/collectd.conf